### PR TITLE
Use prebuilt protoc for cold builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,9 @@
 common --tool_java_language_version=25
 common --tool_java_runtime_version=remotejdk_25
 
+# Avoid compiling protoc from source during cold builds.
+common --@protobuf//bazel/toolchains:prefer_prebuilt_protoc=true
+
 build --nojava_header_compilation
 build --experimental_strict_java_deps=error
 build --explicit_java_test_deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* Use Protobuf's prebuilt `protoc` toolchain to speed up cold Bazel builds.
+
 ### [v1.35.0](https://github.com/realityforge/braincheck/tree/v1.35.0) (2026-07-17) · [Full Changelog](https://github.com/realityforge/braincheck/compare/v1.34.0...v1.35.0)
 
 Changes in this release:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1", dev_dependency = True)
 
 bazel_dep(name = "j2cl", version = "20260717")
+bazel_dep(name = "protobuf", version = "33.4")
 bazel_dep(name = "rules_closure", version = "0.16.0")
 bazel_dep(name = "rules_java", version = "9.7.0")
 bazel_dep(name = "rules_jvm_external", version = "6.7")


### PR DESCRIPTION
## Summary

- make Protobuf 33.4 directly visible to the root module
- configure Bazel to use Protobuf's prebuilt `protoc` toolchain
- document the cold-build improvement in the changelog

## Why

Cold builds currently compile and link the full Protobuf compiler from C++ source. This ports the behavior from [realityforge/zemeckis#2](https://github.com/realityforge/zemeckis/pull/2), allowing Bazel to download the matching prebuilt `protoc` executable instead.

## Validation

- `tools/check.sh`
- all 120 build targets succeeded
- all 7 tests passed
- Bazel toolchain resolution selected `prebuilt_protoc.osx_aarch_64`
